### PR TITLE
bugfix: wrong variable name referenced

### DIFF
--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -118,7 +118,7 @@ function _M.new(opts)
     end
 
     for _, host in ipairs(http_hosts) do
-        local m, err = re_match(http_host, [[\/\/([\d.\w]+):(\d+)]], "jo")
+        local m, err = re_match(host, [[\/\/([\d.\w]+):(\d+)]], "jo")
         if not m then
             return nil, "invalid http host: " .. err
         end


### PR DESCRIPTION
如题

修复当http_host配置为数组/table时，其在一个循环中错误使用了http_host的bug