### PR TITLE
fix: utils.has_value method always return false

### DIFF
--- a/lib/resty/etcd/utils.lua
+++ b/lib/resty/etcd/utils.lua
@@ -69,12 +69,12 @@ end
 
 
 function _M.has_value(arr, val)
-    for index, value in ipairs(arr) do
+    for key, value in pairs(arr) do
         if value == val then
-            return index
+            return key
         end
     end
-
+    
     return false
 end
 

--- a/lib/resty/etcd/v3.lua
+++ b/lib/resty/etcd/v3.lua
@@ -528,6 +528,11 @@ local function request_chunk(self, method, host, port, path, opts, timeout)
                     event.kv.value = decode_json(event.kv.value)
                 end
                 event.kv.key = decode_base64(event.kv.key)
+                if event.prev_kv then
+                    event.prev_kv.value = decode_base64(event.prev_kv.value)
+                    event.prev_kv.value = decode_json(event.prev_kv.value)
+                    event.prev_kv.key = decode_base64(event.prev_kv.key)
+                end
             end
         end
 
@@ -573,7 +578,7 @@ local function watch(self, key, attr)
 
     local prev_kv
     if attr.prev_kv then
-        prev_kv = attr.prev_kv and 'true' or 'false'
+        prev_kv = attr.prev_kv and true or false
     end
 
     local start_revision
@@ -588,12 +593,12 @@ local function watch(self, key, attr)
 
     local progress_notify
     if attr.progress_notify then
-        progress_notify = attr.progress_notify and 'true' or 'false'
+        progress_notify = attr.progress_notify and true or false
     end
 
     local fragment
     if attr.fragment then
-        fragment = attr.fragment and 'true' or 'false'
+        fragment = attr.fragment and true or false
     end
 
     local filters


### PR DESCRIPTION
```
local prefix_v3 = {
    ["3.5."] = "/v3",
    ["3.4."] = "/v3",
    ["3.3."] = "/v3beta",
    ["3.2."] = "/v3alpha",
}

function _M.has_value(arr, val)
    for index, value in ipairs(arr) do
        if value == val then
            return index
        end
    end

    return false
end
```

`prefix_v3` length is 0, so has_value method always return false

